### PR TITLE
Rename hyperTmp sensor to temperature for SF800

### DIFF
--- a/custom_components/zendure_ha/devices/solarflow800.py
+++ b/custom_components/zendure_ha/devices/solarflow800.py
@@ -62,6 +62,6 @@ class SolarFlow800(ZendureDevice):
             self.sensor("gridInputPower", None, "W", "power"),
             self.sensor("pass"),
             self.sensor("strength"),
-            self.sensor("hyperTmp", "{{ (value | float/10 - 273.15) | round(2) }}", "°C", "temperature"),
+            self.sensor("temperature", "{{ (value | float/10 - 273.15) | round(2) }}", "°C", "temperature"),
         ]
         ZendureSensor.addSensors(sensors)


### PR DESCRIPTION
The internal sensor name hyperTmp has been changed to temperature to get the entity ID sensor.solarflow_800_temperature and improve the display in the frontend.