### PR TITLE
Fix detection of maxVol, totalVol and minVol

### DIFF
--- a/custom_components/zendure_ha/zenduredevice.py
+++ b/custom_components/zendure_ha/zenduredevice.py
@@ -71,7 +71,7 @@ class ZendureDevice:
                 entity = self.binary(key, None, "switch")
             elif key.endswith(("Temperature", "Temp")):
                 entity = self.sensor(key, "{{ (value | float/10 - 273.15) | round(2) }}", "°C", "temperature")
-            elif key in ["totalVol", "minVol"]:
+            elif key.endswith(( "totalVol", "minVol", "maxVol" )):
                 entity = self.sensor(key, "{{ (value / 100) }}", "V", "voltage")
             elif key == "batCur":
                 entity = self.sensor(key, "{{ (value / 10) }}")


### PR DESCRIPTION
The change in 2e0ce1c will not detect maxVol, minVol and totalVol as key.