### PR TITLE
Update zendurermanager.py

### DIFF
--- a/custom_components/zendure_ha/zendurermanager.py
+++ b/custom_components/zendure_ha/zendurermanager.py
@@ -271,7 +271,7 @@ class ZendureManager(DataUpdateCoordinator[int]):
             if self.operation == SmartMode.MANUAL:
                 self.updateSetpoint(self.setpoint, ManagerState.DISCHARGING if self.setpoint >= 0 else ManagerState.CHARGING)
             elif powerActual < 0:
-                self.updateSetpoint(powerActual + p1 + 50, ManagerState.CHARGING)
+                self.updateSetpoint(powerActual + p1 + min(abs(p1),MIN_POWER), ManagerState.CHARGING)
             elif powerActual > 0:
                 self.updateSetpoint(powerActual + p1, ManagerState.DISCHARGING)
             elif self.zero_idle == datetime.max:


### PR DESCRIPTION
If actual feed in into grid is < 50, Setpoint should not be higher than  this value. Also use defined value