### PR TITLE
Add serial number to device info in HA

### DIFF
--- a/custom_components/zendure_ha/zenduredevice.py
+++ b/custom_components/zendure_ha/zenduredevice.py
@@ -47,6 +47,7 @@ class ZendureDevice:
             name=self.name,
             manufacturer="Zendure",
             model=model,
+            serial_number=definition.snNumber,
         )
         self._topic_read = f"iot/{self.prodkey}/{self.hid}/properties/read"
         self._topic_write = f"iot/{self.prodkey}/{self.hid}/properties/write"


### PR DESCRIPTION
It makes it easier to identify the device in HA if the serial number is added