### PR TITLE
Update manifest.json Fix Home Assistant

### DIFF
--- a/custom_components/zendure_ha/manifest.json
+++ b/custom_components/zendure_ha/manifest.json
@@ -16,5 +16,5 @@
     "stringcase==1.2.0"
   ],
   "single_config_entry": true,
-  "version": "1.0.37b"
+  "version": "1.0.37"
 }


### PR DESCRIPTION
Home Assistant Core
homeassistant.loader.IntegrationNotFound: Integration 'zendure_ha' not found. 2025-04-25 02:06:02.153 ERROR (MainThread) [homeassistant.helpers.dispatcher] Exception in async_forward_config_entry_changes when dispatching 'config_entry_changed': (<ConfigEntryChange.REMOVED: 'removed'>, <ConfigEntry entry_id=01JSN3NG4V5329AQRGX1586F7C version=1 domain=zendure_ha title=Zendure Integration - ***@outlook.de state=ConfigEntryState.NOT_LOADED unique_id=Zendure Integration - ***@outlook.de>) homeassistant.loader.IntegrationNotLoaded: Integration 'zendure_ha' not loaded. 2025-04-25 02:06:37.827 WARNING (SyncWorker_1) [homeassistant.loader] We found a custom integration zendure_ha which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant 2025-04-25 02:06:37.828 ERROR (SyncWorker_1) [homeassistant.loader] The custom integration 'zendure_ha' does not have a valid version key (1.0.37b) in the manifest file and was blocked from loading. See https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes#versions for more details 2025-04-25 02:07:54.400 WARNING (SyncWorker_0) [homeassistant.loader] We found a custom integration zendure_ha which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant 2025-04-25 02:07:54.400 ERROR (SyncWorker_0) [homeassistant.loader] The custom integration 'zendure_ha' does not have a valid version key (1.0.37b) in the manifest file and was blocked from loading. See https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes#versions for more details


Home Assistant only allows:
Numeric semantic versions, for example:

"1.0.0"

"2.3.1"

"1.0.37"

Why not "1.0.37-b"?
Even though "1.0.37-b" is technically a valid pre-release version according to the Semantic Versioning spec, Home Assistant currently does not accept pre-release tags in the version field.

This is clearly mentioned in their Developer Blog.