### PR TITLE
Resolve AttributeError: 'NoneType' object has no attribute 'default_language_platform_translations'

### DIFF
--- a/custom_components/zendure_ha/zenduredevice.py
+++ b/custom_components/zendure_ha/zenduredevice.py
@@ -388,22 +388,22 @@ class ZendureDevice:
         return s
 
     def asInt(self, name: str) -> int:
-        if (sensor := self.entities.get(name, None)) and sensor.state:
+        if (sensor := self.entities.get(name, None)) and sensor.state is not None:
             return int(sensor.state)
         return 0
 
     def isInt(self, name: str) -> int | None:
-        if (sensor := self.entities.get(name, None)) and sensor.state:
+        if (sensor := self.entities.get(name, None)) and sensor.state is not None:
             return int(sensor.state)
         return None
 
     def asFloat(self, name: str) -> float:
-        if (sensor := self.entities.get(name, None)) and sensor.state:
+        if (sensor := self.entities.get(name, None)) and sensor.state is not None:
             return float(sensor.state)
         return 0
 
     def isEqual(self, name: str, value: Any) -> bool:
-        if (sensor := self.entities.get(name, None)) and sensor.state:
+        if (sensor := self.entities.get(name, None)) and sensor.state is not None:
             return sensor.state == value
         return False
 


### PR DESCRIPTION
HA throws errors on startup, this change fixes it:

2025-04-27 08:36:07.111 ERROR (MainThread) [custom_components.zendure_ha.zendurermanager] Traceback (most recent call last):
  File "/config/custom_components/zendure_ha/zendurermanager.py", line 295, in _update_smart_energyp1
    d.powerAct = d.asInt("packInputPower") - (d.asInt("outputPackPower") - d.asInt("solarInputPower"))
                 ~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/zendure_ha/zenduredevice.py", line 389, in asInt
    if (sensor := self.entities.get(name, None)) and sensor.state:
                                                     ^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 520, in state
    unit_of_measurement = self.unit_of_measurement
                          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 501, in unit_of_measurement
    := self.platform.default_language_platform_translations.get(translation_key)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'default_language_platform_translations'