### PR TITLE
Reset of energy-sensors must be in local time

### DIFF
--- a/custom_components/zendure_ha/zenduredevice.py
+++ b/custom_components/zendure_ha/zenduredevice.py
@@ -210,7 +210,7 @@ class ZendureDevice:
 
     def update_aggr(self, values: list[int]) -> None:
         try:
-            time = dt_util.utcnow()
+            time = dt_util.now()
             for i in range(len(values)):
                 s = self.powerSensors[i]
                 if isinstance(s, ZendureRestoreSensor):


### PR DESCRIPTION
With utcnow() it will be reset in Germany at the moment at 2:00 in the night.

![Reset of Energy Sensor](https://github.com/user-attachments/assets/6f5eabfc-cebb-4f0e-926a-cadbdcf96fa2)
