### PR TITLE
Sensors removed or reconfigured

### DIFF
--- a/custom_components/zendure_ha/devices/aio2400.py
+++ b/custom_components/zendure_ha/devices/aio2400.py
@@ -44,6 +44,8 @@ class AIO2400(ZendureDevice):
 
         switches = [
             self.switch("lampSwitch", None, "switch"),
+            self.switch("masterSwitch", None, "switch"),
+            self.switch("buzzerSwitch", None, "switch"),
         ]
         ZendureSwitch.addSwitches(switches)
 
@@ -70,12 +72,6 @@ class AIO2400(ZendureDevice):
 
         selects = [self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode)]
         ZendureSelect.addSelects(selects)
-        
-        switches = [
-            self.switch("masterSwitch", None, "switch"),
-            self.switch("buzzerSwitch", None, "switch"),
-        ]
-        ZendureSwitch.addSwitches(switches)
 
     def entityUpdate(self, key: Any, value: Any) -> bool:
         # Call the base class entityUpdate method

--- a/custom_components/zendure_ha/devices/aio2400.py
+++ b/custom_components/zendure_ha/devices/aio2400.py
@@ -1,4 +1,4 @@
-"""Module for the Hyper2000 device integration in Home Assistant."""
+"""Module for the AIO2400 device integration in Home Assistant."""
 
 import logging
 from datetime import datetime
@@ -28,8 +28,6 @@ class AIO2400(ZendureDevice):
         super().entitiesCreate()
 
         binaries = [
-            self.binary("masterSwitch", None, "switch"),
-            self.binary("buzzerSwitch", None, "switch"),
             self.binary("wifiState", None, "switch"),
             self.binary("heatState", None, "switch"),
             self.binary("reverseState", None, "switch"),
@@ -72,6 +70,12 @@ class AIO2400(ZendureDevice):
 
         selects = [self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode)]
         ZendureSelect.addSelects(selects)
+        
+        switches = [
+            self.switch("masterSwitch", None, "switch"),
+            self.switch("buzzerSwitch", None, "switch"),
+        ]
+        ZendureSwitch.addSwitches(switches)
 
     def entityUpdate(self, key: Any, value: Any) -> bool:
         # Call the base class entityUpdate method

--- a/custom_components/zendure_ha/devices/hub1200.py
+++ b/custom_components/zendure_ha/devices/hub1200.py
@@ -1,4 +1,4 @@
-"""Module for the Hyper2000 device integration in Home Assistant."""
+"""Module for the Hub1200 device integration in Home Assistant."""
 
 import logging
 from datetime import datetime
@@ -11,6 +11,7 @@ from custom_components.zendure_ha.binary_sensor import ZendureBinarySensor
 from custom_components.zendure_ha.number import ZendureNumber
 from custom_components.zendure_ha.select import ZendureSelect
 from custom_components.zendure_ha.sensor import ZendureSensor
+from custom_components.zendure_ha.switch import ZendureSwitch
 from custom_components.zendure_ha.zenduredevice import ZendureDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,13 +29,9 @@ class Hub1200(ZendureDevice):
         super().entitiesCreate()
 
         binaries = [
-            self.binary("masterSwitch", None, "switch"),
-            self.binary("buzzerSwitch", None, "switch"),
             self.binary("wifiState", None, "switch"),
             self.binary("heatState", None, "switch"),
-            self.binary("reverseState", None, "switch"),
             self.binary("pass", None, "switch"),
-            self.binary("autoRecover", None, "switch"),
         ]
         ZendureBinarySensor.addBinarySensors(binaries)
 
@@ -43,6 +40,7 @@ class Hub1200(ZendureDevice):
             self.number("outputLimit", None, "W", "power", 0, 200, NumberMode.SLIDER),
             self.number("socSet", "{{ value | int / 10 }}", "%", None, 5, 100, NumberMode.SLIDER),
             self.number("minSoc", "{{ value | int / 10 }}", "%", None, 5, 100, NumberMode.SLIDER),
+            self.number("inverseMaxPower", None, "W", "power", 0, 1200, NumberMode.SLIDER),
         ]
         ZendureNumber.addNumbers(self.numbers)
 
@@ -56,18 +54,23 @@ class Hub1200(ZendureDevice):
             self.sensor("remainInputTime", "{{ (value / 60) }}", "h", "duration"),
             self.sensor("packNum", None),
             self.sensor("electricLevel", None, "%", "battery"),
-            self.sensor("energyPower", None, "W"),
-            self.sensor("inverseMaxPower", None, "W"),
             self.sensor("solarPower1", None, "W", "power", "measurement"),
             self.sensor("solarPower2", None, "W", "power", "measurement"),
         ]
         ZendureSensor.addSensors(sensors)
 
-        selects = [self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode)]
+        selects = [
+            self.select("passMode", {0: "auto", 1: "off", 2: "on"}, ),
+            self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode)
+        ]
         ZendureSelect.addSelects(selects)
-
-    def entitiesBattery(self, sensors: list[ZendureSensor]) -> None:
-        sensors.append(self.sensor("soh", "{{ (value / 10) }}", "%", None))
+        
+        switches = [
+            self.switch("masterSwitch", None, "switch"),
+            self.switch("buzzerSwitch", None, "switch"),
+            self.switch("autoRecover", None, "switch"),
+        ]
+        ZendureSwitch.addSwitches(switches)
 
     def entityUpdate(self, key: Any, value: Any) -> bool:
         # Call the base class entityUpdate method

--- a/custom_components/zendure_ha/devices/hyper2000.py
+++ b/custom_components/zendure_ha/devices/hyper2000.py
@@ -31,8 +31,6 @@ class Hyper2000(ZendureDevice):
         super().entitiesCreate()
 
         binaries = [
-            self.binary("masterSwitch", None, "switch"),
-            self.binary("buzzerSwitch", None, "switch"),
             self.binary("wifiState", None, "switch"),
             self.binary("heatState", None, "switch"),
             self.binary("reverseState", None, "switch"),
@@ -79,6 +77,12 @@ class Hyper2000(ZendureDevice):
 
         selects = [self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode)]
         ZendureSelect.addSelects(selects)
+        
+        switches = [
+            self.switch("masterSwitch", None, "switch"),
+            self.switch("buzzerSwitch", None, "switch"),
+        ]
+        ZendureSwitch.addSwitches(switches)
 
     def entityUpdate(self, key: Any, value: Any) -> bool:
         # Call the base class entityUpdate method

--- a/custom_components/zendure_ha/devices/hyper2000.py
+++ b/custom_components/zendure_ha/devices/hyper2000.py
@@ -49,6 +49,8 @@ class Hyper2000(ZendureDevice):
 
         switches = [
             self.switch("lampSwitch", None, "switch"),
+            self.switch("masterSwitch", None, "switch"),
+            self.switch("buzzerSwitch", None, "switch"),
         ]
         ZendureSwitch.addSwitches(switches)
 
@@ -77,12 +79,6 @@ class Hyper2000(ZendureDevice):
 
         selects = [self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode)]
         ZendureSelect.addSelects(selects)
-        
-        switches = [
-            self.switch("masterSwitch", None, "switch"),
-            self.switch("buzzerSwitch", None, "switch"),
-        ]
-        ZendureSwitch.addSwitches(switches)
 
     def entityUpdate(self, key: Any, value: Any) -> bool:
         # Call the base class entityUpdate method

--- a/custom_components/zendure_ha/manifest.json
+++ b/custom_components/zendure_ha/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "zendure_ha",
-  "name": "Zendure Home assistant Integration",
+  "name": "Zendure Home Assistant Integration",
   "codeowners": [
     "@fireson"
   ],

--- a/custom_components/zendure_ha/zendurebattery.py
+++ b/custom_components/zendure_ha/zendurebattery.py
@@ -28,7 +28,6 @@ class ZendureBattery(ZendureBase):
             self.sensor("totalVol", "{{ (value / 100) }}", "V", "voltage", "measurement"),
             self.sensor("maxVol", "{{ (value / 100) }}", "V", "voltage", "measurement"),
             self.sensor("minVol", "{{ (value / 100) }}", "V", "voltage", "measurement"),
-            self.sensor("batcur", "{{ (value / 10) }}", "A", "current", "measurement"),
             self.sensor("state"),
             self.sensor("power", None, "W", "power", "measurement"),
             self.sensor("socLevel", None, "%", "battery", "measurement"),
@@ -37,5 +36,8 @@ class ZendureBattery(ZendureBase):
         ]
         if parent.name == "Hub 1200" or parent.name == "Hub 2000":
             sensors.append(self.sensor("soh", "{{ (value / 10) }}", "%", None))
+            
+        if parent.name == "Hyper 2000":
+            self.sensor("batcur", "{{ (value / 10) }}", "A", "current", "measurement"),
 
         ZendureSensor.addSensors(sensors)

--- a/custom_components/zendure_ha/zendurebattery.py
+++ b/custom_components/zendure_ha/zendurebattery.py
@@ -35,6 +35,7 @@ class ZendureBattery(ZendureBase):
             self.sensor("maxTemp", "{{ (value | float/10 - 273.15) | round(2) }}", "°C", "temperature", "measurement"),
             self.sensor("softVersion"),
         ]
+        if parent.name == "Hub 1200" or parent.name == "Hub 2000":
+            sensors.append(self.sensor("soh", "{{ (value / 10) }}", "%", None))
 
-        parent.entitiesBattery(sensors)
         ZendureSensor.addSensors(sensors)


### PR DESCRIPTION
- SoH entity added to a battery if the parent device is a Hub 1200 or Hub 2000.
- Show `batcur` only if the parent device is a Hyper 2000. No idea whether this also applies to the newer devices.
- `masterSwitch` and `buzzerSwitch` changed from binary to switch for the Hubs, Hyper and AIO. `buzzerSwitch` toggles the confirmation tone on and off.
- `autoRecover` changed from binary to switch for the Hubs. This can be used to specify whether the bypass mode should switch back to its default setting (Automatic) the next day.
- `inverseMaxPower` changed from sensor to number for the hubs. This is the value that defines the maximum power of the connected inverter.
- `reverseState` and `energyPower` removed for the hubs, as the value here is permanently unknown.

The localization JSON still needs to be adapted.