### PR TITLE
Add aggr sensors which do not reset. 

### DIFF
--- a/custom_components/zendure_ha/sensor.py
+++ b/custom_components/zendure_ha/sensor.py
@@ -100,7 +100,6 @@ class ZendureRestoreSensor(ZendureSensor, RestoreEntity):
             secs = time.timestamp() - self.lastValueUpdate.timestamp()
             self._attr_native_value = float(self.state) + self.last_value * secs / 3600000
 
-        _LOGGER.debug(f"Saved state for {self.entity_id}: {self._attr_native_value}")
         self.last_value = value
         self.lastValueUpdate = time
         if self.hass and self.hass.loop.is_running():

--- a/custom_components/zendure_ha/sensor.py
+++ b/custom_components/zendure_ha/sensor.py
@@ -91,15 +91,16 @@ class ZendureRestoreSensor(ZendureSensor, RestoreEntity):
             self._attr_last_reset = dt_util.utcnow()
             _LOGGER.debug(f"Restored state for {self.entity_id}: {self._attr_native_value}")
 
-    def aggregate(self, time: datetime, value: int) -> None:
+    def aggregate(self, time: datetime, value: int, allowReset: bool) -> None:
         # reset the aggregate sensors each day
-        if self.state is None or self.last_reset is None or self.last_reset.date() != time.date():
+        if self.state is None or self.last_reset is None or (self.last_reset.date() != time.date() and allowReset):
             self._attr_native_value = 0.0
             self._attr_last_reset = time
         else:
             secs = time.timestamp() - self.lastValueUpdate.timestamp()
             self._attr_native_value = float(self.state) + self.last_value * secs / 3600000
 
+        _LOGGER.debug(f"Saved state for {self.entity_id}: {self._attr_native_value}")
         self.last_value = value
         self.lastValueUpdate = time
         if self.hass and self.hass.loop.is_running():

--- a/custom_components/zendure_ha/zenduredevice.py
+++ b/custom_components/zendure_ha/zenduredevice.py
@@ -87,6 +87,9 @@ class ZendureDevice(ZendureBase):
         self.powerSensors = [
             self.sensor("aggrChargeDaykWh", None, "kWh", "energy", "total", 2, True),
             self.sensor("aggrDischargeDaykWh", None, "kWh", "energy", "total", 2, True),
+            self.sensor("aggrChargeTotalkWh", None, "kWh", "energy", "total", 2, True),
+            self.sensor("aggrDischargeTotalkWh", None, "kWh", "energy", "total", 2, True),
+            self.sensor("aggrSolarTotalkWh", None, "kWh", "energy", "total", 2, True),
         ]
         ZendureSensor.addSensors(self.powerSensors)
 
@@ -99,10 +102,12 @@ class ZendureDevice(ZendureBase):
         match key:
             case "outputPackPower":
                 self.powerAct = int(value)
-                self.update_aggr([int(value), 0])
+                self.update_aggr([int(value), 0, int(value), 0, 0])
             case "packInputPower":
                 self.powerAct = -int(value)
-                self.update_aggr([0, int(value)])
+                self.update_aggr([0, int(value), 0, int(value), 0])
+            case "solarInputPower":
+                self.update_aggr([0, 0, 0, 0, int(value)])
 
     def entityWrite(self, entity: Entity, value: Any) -> None:
         _LOGGER.info(f"Writing property {self.name} {entity.name} => {value}")
@@ -219,7 +224,7 @@ class ZendureDevice(ZendureBase):
             for i in range(len(values)):
                 s = self.powerSensors[i]
                 if isinstance(s, ZendureRestoreSensor):
-                    s.aggregate(time, values[i])
+                    s.aggregate(time, values[i], i<2)
         except Exception as err:
             _LOGGER.error(err)
 


### PR DESCRIPTION
I added 3 more sensors, which collect all the charge/discharge/solar data. Somehow a meter like the statistics in the Zendure app. These sensors do not reset at midnight.
In general I don't think it's necessary to have daily reset sensors (HA can do this job), but want to have it downwards compatible.

An additional idea is, to allow a preset of these sensors, so you can set it to the total values from the App. But my understanding of the config_flow is too limited to get this done ;-)