### PR TITLE
Update zendurebase.py

### DIFF
--- a/custom_components/zendure_ha/zendurebase.py
+++ b/custom_components/zendure_ha/zendurebase.py
@@ -226,7 +226,7 @@ class ZendureBase:
 
     def aggr(self, name: str, value: int) -> None:
         """Aggregate value to sensor."""
-        if (sensor := self.entities.get(name, None)) and sensor.state is not None and sensor is ZendureRestoreSensor:
+        if (sensor := self.entities.get(name, None)):
             try:
                 time = dt_util.now()
                 sensor.aggregate(time, value)


### PR DESCRIPTION
aggr sensor_state will stay None until it is updated in sensor.aggregate ;-) In my debug (sensor is ZendureRestoreSensor) was always false

However, this may not be the right change to get the sensors not reset to 0 on a restart. So feel free to program a better solution