### PR TITLE
Update zendurermanager.py

### DIFF
--- a/custom_components/zendure_ha/zendurermanager.py
+++ b/custom_components/zendure_ha/zendurermanager.py
@@ -344,7 +344,7 @@ class ZendureManager(DataUpdateCoordinator[int], ZendureBase):
             # get the current power, exit if a device is waiting
             powerActual = 0
             for d in ZendureDevice.devices:
-                d.powerAct = d.asInt("packInputPower") - (d.asInt("outputPackPower") - d.asInt("solarInputPower"))
+                d.powerAct = d.asInt("outputHomePower") - (d.asInt("outputPackPower") - d.asInt("solarInputPower"))
                 powerActual += d.powerAct
 
             _LOGGER.info(f"Update p1: {p1} power: {powerActual} operation: {self.operation}")


### PR DESCRIPTION
Use outputHomePower instead of packInputPower because this is the value P1 refers to
For the Hyper this is not really relevant, but for the Hub 1200, I see a difference for at least 10W between these 2 values.

![image](https://github.com/user-attachments/assets/2247ed46-8bd1-4c5d-a38d-37392cda894e)
