### PR TITLE
Allow change of the Bypass setting

### DIFF
--- a/custom_components/zendure_ha/devices/hub1200.py
+++ b/custom_components/zendure_ha/devices/hub1200.py
@@ -64,7 +64,10 @@ class Hub1200(ZendureDevice):
         ]
         ZendureSensor.add(sensors)
 
-        selects = [self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode)]
+        selects = [
+            self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode),
+            self.select("passMode", {0: "auto", 1: "on", 2: "off"}, self.update_bypass),
+        ]
         ZendureSelect.add(selects)
 
     def entitiesBattery(self, battery: ZendureBattery, sensors: list[ZendureSensor]) -> None:

--- a/custom_components/zendure_ha/devices/hub2000.py
+++ b/custom_components/zendure_ha/devices/hub2000.py
@@ -64,7 +64,10 @@ class Hub2000(ZendureDevice):
         ]
         ZendureSensor.add(sensors)
 
-        selects = [self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode)]
+        selects = [
+            self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode),
+            self.select("passMode", {0: "auto", 1: "on", 2: "off"}, self.update_bypass),
+        ]
         ZendureSelect.add(selects)
 
     def entitiesBattery(self, battery: ZendureBattery, _sensors: list[ZendureSensor]) -> None:

--- a/custom_components/zendure_ha/devices/hyper2000.py
+++ b/custom_components/zendure_ha/devices/hyper2000.py
@@ -92,14 +92,16 @@ class Hyper2000(ZendureDevice):
             self.sensor("OldMode"),
             self.sensor("circuitCheckMode"),
             self.sensor("dspversion"),
-            self.sensor("gridReverse"),
             self.sensor("gridOffMode"),
         ]
         ZendureSensor.add(sensors)
 
         self.nosensor(["invOutputPower"])
 
-        selects = [self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode)]
+        selects = [
+            self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode),
+            self.select("gridReverse", {0: "auto", 1: "on", 2: "off"}, self.update_bypass),
+        ]
         ZendureSelect.add(selects)
 
     def entityUpdate(self, key: Any, value: Any) -> bool:

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -229,6 +229,14 @@
           "off": "Immer aus",
           "on": "Immer an"
         }
+      },
+      "grid_reverse": {
+        "name": "Bypass-Modus",
+        "state": {
+          "auto": "Automatisch",
+          "off": "Immer aus",
+          "on": "Immer an"
+        }
       }
     },
     "switch": {

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -222,7 +222,7 @@
           "smart": "Smarte Leistungsregelung"
         }
       },
-      "pass_mode": {
+      "grid_reverse": {
         "name": "Bypass-Modus",
         "state": {
           "auto": "Automatisch",

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -222,7 +222,7 @@
           "smart": "Smarte Leistungsregelung"
         }
       },
-      "grid_reverse": {
+      "pass_mode": {
         "name": "Bypass-Modus",
         "state": {
           "auto": "Automatisch",

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -227,7 +227,7 @@
           "smart": "Smart Matching"
         }
       },
-      "grid_reverse": {
+      "pass_mode": {
         "name": "Bypass Mode",
         "state": {
           "auto": "Auto",

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -227,7 +227,7 @@
           "smart": "Smart Matching"
         }
       },
-      "pass_mode": {
+      "grid_reverse": {
         "name": "Bypass Mode",
         "state": {
           "auto": "Auto",

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -234,6 +234,14 @@
           "off": "Always-Off",
           "on": "Always-On"
         }
+      },
+      "grid_reverse": {
+        "name": "Bypass Mode",
+        "state": {
+          "auto": "Auto",
+          "off": "Always-Off",
+          "on": "Always-On"
+        }
       }
     },
     "switch": {

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -219,7 +219,7 @@
           "smart": "Couplage intelligent"
         }
       },
-      "grid_reverse": {
+      "pass_mode": {
         "name": "Mode contournement ( bypass )",
         "state": {
           "auto": "Automatique",

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -219,7 +219,7 @@
           "smart": "Couplage intelligent"
         }
       },
-      "pass_mode": {
+      "grid_reverse": {
         "name": "Mode contournement ( bypass )",
         "state": {
           "auto": "Automatique",

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -226,6 +226,14 @@
           "off": "Toujours désactivé",
           "on": "Toujours activé"
         }
+      },
+      "grid_reverse": {
+        "name": "Mode contournement ( bypass )",
+        "state": {
+          "auto": "Automatique",
+          "off": "Toujours désactivé",
+          "on": "Toujours activé"
+        }
       }
     },
     "switch": {

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -173,7 +173,7 @@
           "smart": "Slimme Matching"
         }
       },
-      "pass_mode": {
+      "grid_reverse": {
         "name": "Bypass-modus",
         "state": {
           "auto": "Automatisch",

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -180,6 +180,14 @@
           "off": "Altijd Uit",
           "on": "Altijd Aan"
         }
+      },
+      "grid_reverse": {
+        "name": "Bypass-modus",
+        "state": {
+          "auto": "Automatisch",
+          "off": "Altijd Uit",
+          "on": "Altijd Aan"
+        }
       }
     },
     "switch": {

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -173,7 +173,7 @@
           "smart": "Slimme Matching"
         }
       },
-      "grid_reverse": {
+      "pass_mode": {
         "name": "Bypass-modus",
         "state": {
           "auto": "Automatisch",

--- a/custom_components/zendure_ha/zenduredevice.py
+++ b/custom_components/zendure_ha/zenduredevice.py
@@ -242,6 +242,9 @@ class ZendureDevice(ZendureBase):
         elif mode == AcMode.OUTPUT:
             self.writeProperties({"acMode": mode, "outputLimit": self.asInt("outputLimit")})
 
+    def update_bypass(self, _entity: ZendureSelect, mode: int) -> None:
+        self.writeProperties({"gridReverse": mode})
+
     def writeProperties(self, props: dict[str, Any]) -> None:
         ZendureDevice._messageid += 1
         payload = json.dumps(

--- a/custom_components/zendure_ha/zendurermanager.py
+++ b/custom_components/zendure_ha/zendurermanager.py
@@ -358,7 +358,7 @@ class ZendureManager(DataUpdateCoordinator[int], ZendureBase):
 
             # update when we are discharging
             elif powerActual > 0:
-                self.updateSetpoint(max(0, powerActual + p1), ManagerState.DISCHARGING)
+                self.updateSetpoint(max(0, powerActual + p1 + d.offset), ManagerState.DISCHARGING)
 
             # check if it is the first time we are idle
             elif self.zero_idle == datetime.max:
@@ -400,7 +400,7 @@ class ZendureManager(DataUpdateCoordinator[int], ZendureBase):
                 d.capacity = 0
             totalCapacity += d.capacity
 
-        _LOGGER.info(f"Update setpoint: {power} state{state} capacity: {totalCapacity} max: {totalPower}")
+        _LOGGER.info(f"Update setpoint: {power} state{state} capacity: {totalCapacity} max: {totalPower} offset: {d.offset}")
 
         # redistribute the power on clusters
         isreverse = bool(abs(power) > totalPower / 2)


### PR DESCRIPTION
This commits allow to change the Bypass settings. For the Hyper I could succesfully test it, for the HUB 1200 if do have logs that confirm, that there is no gridReverse but the passMode, so I'm pretty sure, that this will work.
For the other devices I have no information if passMode or gridReverse is used.

The first commits b4bd600 and 7100977 include changes for an offset on discharging and the change wrt to the aggr sensors. You don't need to use these 2 commtis, but I have no idea how to exclude them from a PR. :-|

![image](https://github.com/user-attachments/assets/f6622c64-c04e-4955-b628-981d362f7900)
