### PR TITLE
Smart mode: Take empty battery and Bypass ON into account

### DIFF
--- a/custom_components/zendure_ha/zendurermanager.py
+++ b/custom_components/zendure_ha/zendurermanager.py
@@ -379,7 +379,9 @@ class ZendureManager(DataUpdateCoordinator[int], ZendureBase):
             # get the current power, exit if a device is waiting
             powerActual = 0
             for d in ZendureDevice.devices:
-                d.powerAct = d.asInt("packInputPower") - (d.asInt("outputPackPower") - d.asInt("solarInputPower"))
+                d.powerAct = d.asInt("packInputPower") - d.asInt("outputPackPower")
+                if d.powerAct != 0:
+                    d.powerAct += d.asInt("solarInputPower")
                 powerActual += d.powerAct
 
             _LOGGER.info(f"Update p1: {p1} power: {powerActual} operation: {self.operation}")


### PR DESCRIPTION
If there is a discharge and Bypass is ON, and let's say the house demand is 200W, solarinput delivers 100W and battery  (packInputPower) also 100W. Now the battery reaches the minSOC, so the battery deliver no power anymore.  No problem so far, P1 will be 100W d.powerAct = 0 - (0 - 100) = +100. Now the solarInputPower rises to 400W, house demand is still 200W --> P1 = -200W, d.powerAct = +400
In the following if clause, it will keep discharging and will only switch to charge, if the solarInputPower get to 0. So only if packInoutPower or outputPackPower > 0, we can take the solarInput into account. I'm not sure, if it can happen that packInoutPower equals outputPackPower (perhaps if Bypass = OFF, and it charges the same amount from solarInput as it discharge out of the battery to home)?? Then we need to test both against 0.