### PR TITLE
AIO 2400 and autoRecover for HUB family and AIO

### DIFF
--- a/custom_components/zendure_ha/devices/aio2400.py
+++ b/custom_components/zendure_ha/devices/aio2400.py
@@ -69,7 +69,11 @@ class AIO2400(ZendureDevice):
         ]
         ZendureSensor.add(sensors)
 
-        selects = [self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode)]
+        selects = [
+            self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode),
+            self.select("passMode", {0: "auto", 1: "on", 2: "off"}),
+            self.select("autoRecover", {0: "off", 1: "on"}),
+        ]
         ZendureSelect.add(selects)
 
     def entityUpdate(self, key: Any, value: Any) -> bool:

--- a/custom_components/zendure_ha/devices/hub1200.py
+++ b/custom_components/zendure_ha/devices/hub1200.py
@@ -35,7 +35,6 @@ class Hub1200(ZendureDevice):
             self.binary("heatState"),
             self.binary("reverseState"),
             self.binary("pass"),
-            self.binary("autoRecover"),
         ]
         ZendureBinarySensor.add(binaries)
 

--- a/custom_components/zendure_ha/devices/hub1200.py
+++ b/custom_components/zendure_ha/devices/hub1200.py
@@ -67,6 +67,7 @@ class Hub1200(ZendureDevice):
         selects = [
             self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode),
             self.select("passMode", {0: "auto", 2: "on", 1: "off"}),
+            self.select("autoRecover", {0: "off", 1: "on"}),
         ]
         ZendureSelect.add(selects)
 

--- a/custom_components/zendure_ha/devices/hub2000.py
+++ b/custom_components/zendure_ha/devices/hub2000.py
@@ -67,6 +67,7 @@ class Hub2000(ZendureDevice):
         selects = [
             self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode),
             self.select("passMode", {0: "auto", 1: "on", 2: "off"}),
+            self.select("autoRecover", {0: "off", 1: "on"}),
         ]
         ZendureSelect.add(selects)
 

--- a/custom_components/zendure_ha/devices/hub2000.py
+++ b/custom_components/zendure_ha/devices/hub2000.py
@@ -35,7 +35,6 @@ class Hub2000(ZendureDevice):
             self.binary("heatState"),
             self.binary("reverseState"),
             self.binary("pass"),
-            self.binary("autoRecover"),
         ]
         ZendureBinarySensor.add(binaries)
 

--- a/custom_components/zendure_ha/zendurebattery.py
+++ b/custom_components/zendure_ha/zendurebattery.py
@@ -19,7 +19,7 @@ class ZendureBattery(ZendureBase):
 
     batterydict: dict[str, ZendureBattery] = {}
 
-    def __init__(self, hass: HomeAssistant, name: str, model: str, snNumber: str, parent: str, kwh: int) -> None:
+    def __init__(self, hass: HomeAssistant, name: str, model: str, snNumber: str, parent: str, kwh: float) -> None:
         """Initialize ZendureBattery."""
         super().__init__(hass, name, model, snNumber, parent)
         self.batterydict[snNumber] = self

--- a/custom_components/zendure_ha/zenduredevice.py
+++ b/custom_components/zendure_ha/zenduredevice.py
@@ -179,7 +179,7 @@ class ZendureDevice(ZendureBase):
                                     case "A":
                                         if sn[3] == "3":
                                             bat = ZendureBattery(self._hass, sn, "AIO2400", sn, self.name, 2.4)
-                                        elif
+                                        else:
                                             bat = ZendureBattery(self._hass, sn, "AB1000", sn, self.name, 0.96)
                                     case "B":
                                         bat = ZendureBattery(self._hass, sn, "AB1000S", sn, self.name, 0.96)

--- a/custom_components/zendure_ha/zenduredevice.py
+++ b/custom_components/zendure_ha/zenduredevice.py
@@ -177,15 +177,18 @@ class ZendureDevice(ZendureBase):
                             if (bat := ZendureBattery.batterydict.get(sn, None)) is None:
                                 match sn[0]:
                                     case "A":
-                                        bat = ZendureBattery(self._hass, sn, "AB1000", sn, self.name, 1)
+                                        if sn[3] == "3":
+                                            bat = ZendureBattery(self._hass, sn, "AIO2400", sn, self.name, 2.4)
+                                        elif
+                                            bat = ZendureBattery(self._hass, sn, "AB1000", sn, self.name, 0.96)
                                     case "B":
-                                        bat = ZendureBattery(self._hass, sn, "AB1000S", sn, self.name, 1)
+                                        bat = ZendureBattery(self._hass, sn, "AB1000S", sn, self.name, 0.96)
                                     case "C":
-                                        bat = ZendureBattery(self._hass, sn, "AB2000" + ("S" if sn[3] == "F" else ""), sn, self.name, 2)
+                                        bat = ZendureBattery(self._hass, sn, "AB2000" + ("S" if sn[3] == "F" else ""), sn, self.name, 1.92)
                                     case "F":
-                                        bat = ZendureBattery(self._hass, sn, "AB3000", sn, self.name, 3)
+                                        bat = ZendureBattery(self._hass, sn, "AB3000", sn, self.name, 2.88)
                                     case _:
-                                        bat = ZendureBattery(self._hass, sn, "AB????", sn, self.name, 3)
+                                        bat = ZendureBattery(self._hass, sn, "AB????", sn, self.name, 2.88)
                                 self.kwh += bat.kwh
                                 done = threading.Event()
                                 self._hass.loop.call_soon_threadsafe(bat.entitiesCreate, self.entitiesBattery, done)


### PR DESCRIPTION
Added Bypass selection for AIO 2400 and selection for autoRecover for HUB family and AIO.
Added AIO battery and changed capacities for the batteries to have precise values (also for later enhancements as SoH for all ;-)  )

Refer to #301

![image](https://github.com/user-attachments/assets/1f8585de-0f92-40f8-8116-328019e85087)
