### PR TITLE
Update hub2000.py

### DIFF
--- a/custom_components/zendure_ha/devices/hub2000.py
+++ b/custom_components/zendure_ha/devices/hub2000.py
@@ -73,7 +73,7 @@ class Hub2000(ZendureDevice):
 
     def entitiesBattery(self, battery: ZendureBattery, _sensors: list[ZendureSensor]) -> None:
         self.batCount += 1
-        self.powerMin = (-1200 if battery.kwh == 2 else -800) if self.batCount == 1 else -1800
+        self.powerMin = (-1200 if battery.kwh > 1 else -800) if self.batCount == 1 else -1800
         self.numbers[0].update_range(0, abs(self.powerMin))
 
     def entityUpdate(self, key: Any, value: Any) -> bool:

--- a/custom_components/zendure_ha/devices/hub2000.py
+++ b/custom_components/zendure_ha/devices/hub2000.py
@@ -66,7 +66,7 @@ class Hub2000(ZendureDevice):
 
         selects = [
             self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode),
-            self.select("passMode", {0: "auto", 1: "on", 2: "off"}),
+            self.select("passMode", {0: "auto", 2: "on", 1: "off"}),
             self.select("autoRecover", {0: "off", 1: "on"}),
         ]
         ZendureSelect.add(selects)


### PR DESCRIPTION
Changed back again. #313 and #265 state that 1.0.43 version is wrong. This makes also more sense, because HUB 1200 and AIO 2400 have it that way (2: "on", 1: "off")