### PR TITLE
Update zendurebase.py

### DIFF
--- a/custom_components/zendure_ha/zendurebase.py
+++ b/custom_components/zendure_ha/zendurebase.py
@@ -277,6 +277,6 @@ class ZendureBase:
         if value <= 0 or level >= soc:
             return 0
         value = float(value) / 60
-        if value >= 999 or level == 0:
+        if value >= 999:
             return 999
         return value * (soc - level) / (100 - level)


### PR DESCRIPTION
Level == 0 means battery is completely empty (will most likely never happen) but if there is a valid time, there is no need to set remainig time to 999