### PR TITLE
Offset

### DIFF
--- a/custom_components/zendure_ha/config_flow.py
+++ b/custom_components/zendure_ha/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import selector
 
 from .api import Api
 from .const import (CONF_MQTTLOCAL, CONF_MQTTLOG, CONF_P1METER, CONF_WIFIPSW,
-                    CONF_WIFISSID, DOMAIN)
+                    CONF_WIFISSID, CONF_EXPERIMENT, DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,6 +37,7 @@ class ZendureConfigFlow(ConfigFlow, domain=DOMAIN):
         ),
         vol.Required(CONF_P1METER, description={"suggested_value": "sensor.power_actual"}): str,
         vol.Required(CONF_MQTTLOCAL): bool,
+        vol.Required(CONF_EXPERIMENT): bool,
         vol.Required(CONF_MQTTLOG): bool,
         vol.Required(CONF_WIFISSID): str,
         vol.Required(CONF_WIFIPSW): selector.TextSelector(
@@ -142,6 +143,7 @@ class ZendureOptionsFlowHandler(OptionsFlow):
             data_schema=vol.Schema({
                 vol.Required(CONF_P1METER, description={"suggested_value": "sensor.power_actual"}): str,
                 vol.Required(CONF_MQTTLOG): bool,
+                vol.Required(CONF_EXPERIMENT): bool,
             }),
         )
 

--- a/custom_components/zendure_ha/const.py
+++ b/custom_components/zendure_ha/const.py
@@ -13,6 +13,7 @@ CONF_MQTTUSER = "mqttuser"
 CONF_MQTTPSW = "mqttpsw"
 CONF_WIFISSID = "wifissid"
 CONF_WIFIPSW = "wifipsw"
+CONF_EXPERIMENT = "experiment"
 
 
 class ManagerState(Enum):

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -18,7 +18,8 @@
           "mqttlog": "MQTT-Kommunikation loggen",
           "mqttlocal": "Lokalen MQTT verwenden",
           "wifissid": "Wifi SSID",
-          "wifipsw": "Wifi Passwort"
+          "wifipsw": "Wifi Passwort",
+	        "experiment": "Experimentelle Funktionen"
         }
       },
       "reconfigure": {
@@ -29,7 +30,8 @@
           "mqttlog": "MQTT-Kommunikation loggen",
           "mqttlocal": "Lokalen Mosquitto MQTT AddOn verwenden",
           "wifissid": "Wifi SSID",
-          "wifipsw": "Wifi Passwort"
+          "wifipsw": "Wifi Passwort",
+	        "experiment": "Experimentelle Funktionen"
         }
       }
     }
@@ -69,6 +71,9 @@
       },
       "soc_set": {
         "name": "SOC Maximum"
+      },
+      "offset": {
+        "name": "Offset Nulleinspeisung"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -18,7 +18,8 @@
           "mqttlocal": "Use local MQTT",
           "mqttlog": "Log MQTT communication",
           "wifissid": "Wifi SSID",
-          "wifipsw": "Wifi Password"
+          "wifipsw": "Wifi Password",
+		  "experiment": "experimental functions"
         }
       },
       "reconfigure": {
@@ -29,7 +30,8 @@
           "mqttlocal": "Use local MQTT",
           "mqttlog": "Log MQTT communication",
           "wifissid": "Wifi SSID",
-          "wifipsw": "Wifi Password"
+          "wifipsw": "Wifi Password",
+		  "experiment": "experimental functions"
         }
       }
     }
@@ -69,6 +71,9 @@
       },
       "soc_set": {
         "name": "SOC Maximum"
+      },
+      "offset": {
+        "name": "Offset zero feed"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -18,7 +18,8 @@
           "mqttlog": "Journaliser la communication MQTT",
           "mqttlocal": "Utiliser MQTT local",
           "wifissid": "SSID Wi-Fi",
-          "wifipsw": "Mot de passe Wi-Fi"
+          "wifipsw": "Mot de passe Wi-Fi",
+		      "experiment": "experimental functions"
         }
       },
       "reconfigure": {
@@ -29,7 +30,8 @@
           "mqttlog": "Journaliser la communication MQTT",
           "mqttlocal": "Utiliser Mosquitto MQTT AddOn local",
           "wifissid": "SSID Wi-Fi",
-          "wifipsw": "Mot de passe Wi-Fi"
+          "wifipsw": "Mot de passe Wi-Fi",
+		      "experiment": "experimental functions"
         }
       }
     }
@@ -69,6 +71,9 @@
       },
       "soc_set": {
         "name": "SOC maximum"
+      },
+      "offset": {
+        "name": "Décalage de l'avance nulle"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -18,7 +18,8 @@
           "mqttlog": "MQTT-Communicatie loggen",
           "mqttlocal": "Lokale MQTT gebruiken",
           "wifissid": "Wifi SSID",
-          "wifipsw": "Wifi Wachtwoord"
+          "wifipsw": "Wifi Wachtwoord",
+		      "experiment": "experimental functions"
         }
       },
       "reconfigure": {
@@ -29,7 +30,8 @@
           "mqttlog": "MQTT-Communicatie loggen",
           "mqttlocal": "Lokale Mosquitto MQTT AddOn gebruiken",
           "wifissid": "Wifi SSID",
-          "wifipsw": "Wifi Wachtwoord"
+          "wifipsw": "Wifi Wachtwoord",
+		      "experiment": "experimental functions"
         }
       }
     }
@@ -69,6 +71,9 @@
       },
       "soc_set": {
         "name": "SOC Maximaal"
+      },
+      "offset": {
+        "name": "Offset nulvoeding"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/zenduredevice.py
+++ b/custom_components/zendure_ha/zenduredevice.py
@@ -41,6 +41,7 @@ class ZendureDevice(ZendureBase):
     mqttIsLocal: bool = False
     mqttLocalUrl = ""
     mqttLog: bool = False
+    experiment: bool = False
     wifissid: str | None = None
     wifipsw: str | None = None
     _messageid = 700000


### PR DESCRIPTION
This PR does the following:

- allow numbers to be persistent
- add a config entry "Experimental functions"
- add an offset-slider to the Zendure-Manager, if Experimental functions are enabled
- This offset-slider allow a threshold around 0. You can select, (offset > 0) if you want to spent more into grid and use not all of the solar power to load the battery, with the idea to get as less from the grid as possible. Or you select offset < 0 and than you be sure not to spent battery power into grid and also use all solar power to charge batteries. This is usefull in winter, where you need to get power from the grid anyway.
- This also reduces switching between charge and discharge. It create a kind of corridor where the system is in standby.
- If we now also increase TIMEIDLE (or make it also configurable) to let's say 60 or 120 sec. Then this mean that switching will reduced even more. This is not yet in this PR
- We also can consider to increase the idle-time in special circumstances, but did not think for now on it, how this can work.

This is part of the discussionin #272  