### PR TITLE
Update zendurermanager.py

### DIFF
--- a/custom_components/zendure_ha/zendurermanager.py
+++ b/custom_components/zendure_ha/zendurermanager.py
@@ -238,7 +238,7 @@ class ZendureManager(DataUpdateCoordinator[int], ZendureBase):
 
             for device in ZendureDevice.devices:
                 # Reset MQTT server each day and when it is not responding
-                if midnight or (checkreset and device.mqttLocal + device.mqttZendure == 0):
+                if midnight or (checkreset and (device.mqttLocal + device.mqttZendure == 0 or self.bleErr)):
                     await device.bleMqtt()
 
                 # check for bluetooth device


### PR DESCRIPTION
I had several timeouts without a mqttReset for more than 2 hours. But I see, that if there is a bleErr, mqttZendure still can be > 0

![image](https://github.com/user-attachments/assets/3b86fe2a-2661-4371-8666-13f3bc48afd9)
