### PR TITLE
Handle ble errors & mqtt reset

### DIFF
--- a/custom_components/zendure_ha/zenduredevice.py
+++ b/custom_components/zendure_ha/zenduredevice.py
@@ -6,7 +6,7 @@ import json
 import logging
 import threading
 import traceback
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 from bleak import BleakClient
@@ -154,6 +154,7 @@ class ZendureDevice(ZendureBase):
         self.mqttClient.publish(self.topic_function, payload)
 
     def mqttMessage(self, topics: list[str], payload: Any) -> bool:
+        self.check_reset = datetime.now() + timedelta(seconds=300)
         try:
             parameter = topics[-1]
             match parameter:

--- a/custom_components/zendure_ha/zendurermanager.py
+++ b/custom_components/zendure_ha/zendurermanager.py
@@ -332,7 +332,7 @@ class ZendureManager(DataUpdateCoordinator[int], ZendureBase):
                     if device.mqttLocal == 1:
                         device.mqttStatus()
 
-                if ZendureDevice.mqttIsLocal and (device.mqttLocal < 8 or device.mqttZenApp != datetime.min) and topics[0] == "":
+                if ZendureDevice.mqttIsLocal and ((device.mqttLocal & 15) < 8 or device.mqttZenApp != datetime.min) and topics[0] == "":
                     ZendureDevice.mqttCloud.publish(msg.topic, msg.payload)
 
             else:


### PR DESCRIPTION
There is no need to suppress MQTT communication in local mode if there are BLE errors and there is also no need to force a MQTT reset, if MQTT commands come in.

I have sometimes BLE timeouts, the actual implementation suppress MQTT communication and start a MQTT reset which switch off local mode. This is not necessary.

![image](https://github.com/user-attachments/assets/bdd634e6-db28-41cf-b2e7-2cb679563fba)
