### PR TITLE
(dis)charge only

### DIFF
--- a/custom_components/zendure_ha/const.py
+++ b/custom_components/zendure_ha/const.py
@@ -41,6 +41,8 @@ class SmartMode:
     NONE = 0
     MANUAL = 1
     MATCHING = 2
+    MATCHING_DISCHARGE = 3
+    MATCHING_CHARGE = 4
     FAST_UPDATE = 100
     MIN_POWER = 50
     START_POWER = 100

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -264,8 +264,8 @@
           "off": "Aus",
           "manual": "Manuelle Leistungsregelung",
           "smart": "Smarte Leistungsregelung",
-          "smartD": "Smartes nur Entladen",
-          "smartC": "Smartes nur Laden"
+          "smart_d": "Smartes nur Entladen",
+          "smart_c": "Smartes nur Laden"
         }
       },
       "pass_mode": {

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -111,7 +111,11 @@
           "9": "Zendure App und BLE",
           "10": "Lokal Mqtt und Zendure App",
           "11": "Lokal Mqtt, Zendure App und BLE",
-          "16": "BLE Fehler"
+          "16": "BLE Fehler",
+          "18": "lokal MQTT und BLE Fehler",
+          "20": "Zendure Cloud und BLE Fehler",
+          "22": "Zendure App und BLE Fehler",
+          "24": "Lokal Mqtt, Zendure App und BLE Fehler"
         }
       },
       "so_h": {
@@ -259,7 +263,9 @@
         "state": {
           "off": "Aus",
           "manual": "Manuelle Leistungsregelung",
-          "smart": "Smarte Leistungsregelung"
+          "smart": "Smarte Leistungsregelung",
+          "smartD": "Smartes nur Entladen",
+          "smartC": "Smartes nur Laden"
         }
       },
       "pass_mode": {

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -261,8 +261,8 @@
           "off": "Off",
           "manual": "Manual Power",
           "smart": "Smart Matching",
-          "smartD": "Smart discharge only",
-          "smartC": "Smart charge only"
+          "smart_d": "Smart discharge only",
+          "smart_c": "Smart charge only"
         }
       },
       "pass_mode": {

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -111,7 +111,11 @@
           "9": "Zendure App and BLE",
           "10": "Local Mqtt, Zendure App",
           "11": "Local Mqtt, Zendure App and BLE",
-          "16": "BLE Error"
+          "16": "BLE Error",
+          "18": "lokal MQTT and BLE Error",
+          "20": "Zendure Cloud and BLE Error",
+          "22": "Zendure App and BLE Error",
+          "24": "Lokal Mqtt, Zendure App and BLE Error"
         }
       },
       "so_h": {
@@ -256,7 +260,9 @@
         "state": {
           "off": "Off",
           "manual": "Manual Power",
-          "smart": "Smart Matching"
+          "smart": "Smart Matching",
+          "smartD": "Smart discharge only",
+          "smartC": "Smart charge only"
         }
       },
       "pass_mode": {

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -261,8 +261,8 @@
           "off": "Arrêt",
           "manual": "Puissance manuelle",
           "smart": "Couplage intelligent",
-          "smartD": "Décharge intelligente",
-          "smartC": "Charge intelligente"
+          "smart_d": "Décharge intelligente",
+          "smart_c": "Charge intelligente"
         }
       },
       "pass_mode": {

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -111,7 +111,11 @@
           "9": "Zendure App et BLE",
           "10": "Local Mqtt et Zendure App",
           "11": "Local Mqtt, Zendure App et BLE",
-          "16": "BLE Error"
+          "16": "Erreur BLE",
+          "18": "lokal MQTT et Erreur BLE",
+          "20": "Zendure Cloud et Erreur BLE",
+          "22": "Zendure App et Erreur BLE",
+          "24": "Lokal Mqtt, Zendure App et Erreur BLE"
         }
       },
       "so_h": {
@@ -256,7 +260,9 @@
         "state": {
           "off": "Arrêt",
           "manual": "Puissance manuelle",
-          "smart": "Couplage intelligent"
+          "smart": "Couplage intelligent",
+          "smartD": "Décharge intelligente",
+          "smartC": "Charge intelligente"
         }
       },
       "pass_mode": {

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -223,8 +223,8 @@
           "off": "Uit",
           "manual": "Handmatig Vermogen",
           "smart": "Slimme Matching",
-          "smartD": "Slimme ontlading",
-          "smartC": "Slimme opladen"
+          "smart_d": "Slimme ontlading",
+          "smart_c": "Slimme opladen"
         }
       },
       "pass_mode": {

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -111,7 +111,11 @@
           "9": "Zendure App en BLE",
           "10": "Lokale Mqtt, Zendure App",
           "11": "Lokale Mqtt, Zendure App en BLE",
-          "16": "BLE Fout"
+          "16": "BLE Fout",
+          "18": "lokal MQTT en BLE Fout",
+          "20": "Zendure Cloud en BLE Fout",
+          "22": "Zendure App en BLE Fout",
+          "24": "Lokal Mqtt, Zendure App en BLE Fout"
         }
       },
       "so_h": {
@@ -166,6 +170,14 @@
           "2": "Ontladen"
         }
       },
+      "state": {
+        "name": "Status",
+        "state": {
+          "0": "Inactief",
+          "1": "Laden",
+          "2": "Ontladen"
+        }
+      },
       "pack_input_power": {
         "name": "Batterij Ontladen"
       },
@@ -210,7 +222,9 @@
         "state": {
           "off": "Uit",
           "manual": "Handmatig Vermogen",
-          "smart": "Slimme Matching"
+          "smart": "Slimme Matching",
+          "smartD": "Slimme ontlading",
+          "smartC": "Slimme opladen"
         }
       },
       "pass_mode": {

--- a/custom_components/zendure_ha/zendurermanager.py
+++ b/custom_components/zendure_ha/zendurermanager.py
@@ -90,7 +90,7 @@ class ZendureManager(DataUpdateCoordinator[int], ZendureBase):
             # Add ZendureManager sensors
             _LOGGER.info(f"Adding sensors {self.name}")
             selects = [
-                self.select("Operation", {0: "off", 1: "manual", 2: "smart", 3: "smartD", 4: "smartC"}, self.update_operation, True),
+                self.select("Operation", {0: "off", 1: "manual", 2: "smart", 3: "smart_d", 4: "smart_c"}, self.update_operation, True),
             ]
             ZendureSelect.add(selects)
 


### PR DESCRIPTION
This PR add the translations for the combination with the BLE Error and add two new manager modes: Smart Charge and Discharge only. 
In fact it set the setpoint to 0 if the P1 sensor request charging if only discharging is allowed and vice versa.
I also added a change of the Manager-Mode to None, if the min/max SOC is reached in Manual or (Dis)Charge only mode.