### PR TITLE
Battery ghostbuster

### DIFF
--- a/custom_components/zendure_ha/zendurebattery.py
+++ b/custom_components/zendure_ha/zendurebattery.py
@@ -18,12 +18,21 @@ class ZendureBattery(ZendureBase):
     """A Zendure Battery."""
 
     batterydict: dict[str, ZendureBattery] = {}
+    batterycontrol: dict[str, int] = {}
 
     def __init__(self, hass: HomeAssistant, name: str, model: str, snNumber: str, parent: str, kwh: float) -> None:
-        """Initialize ZendureBattery."""
-        super().__init__(hass, name, model, snNumber, parent)
-        self.batterydict[snNumber] = self
-        self.kwh = kwh
+        if (self.batterycontrol.get(snNumber, None) is None):
+            self.batterycontrol[snNumber] = 0
+            _LOGGER.info(f"First occurrence of battery: {snNumber}")
+        else:
+            self.batterycontrol[snNumber] = self.batterycontrol[snNumber]+1
+            
+        if self.batterycontrol[snNumber]>2:
+            """Initialize ZendureBattery."""
+            _LOGGER.info(f"Add battery with SN: {snNumber} to the devices")
+            super().__init__(hass, name, model, snNumber, parent)
+            self.batterydict[snNumber] = self
+            self.kwh = kwh
 
     def entitiesCreate(self, addsensors: Callable[[ZendureBattery, list[ZendureSensor]], None], event: Any) -> None:
         sensors = [

--- a/custom_components/zendure_ha/zenduredevice.py
+++ b/custom_components/zendure_ha/zenduredevice.py
@@ -171,7 +171,7 @@ class ZendureDevice(ZendureBase):
                         for b in batprops:
                             sn = b.pop("sn")
 
-                            if ((bat := ZendureBattery.batterydict.get(sn, None)) is None):
+                            if (bat := ZendureBattery.batterydict.get(sn, None)) is None:
                                 match sn[0]:
                                     case "A":
                                         if sn[3] == "3":

--- a/custom_components/zendure_ha/zenduredevice.py
+++ b/custom_components/zendure_ha/zenduredevice.py
@@ -170,10 +170,8 @@ class ZendureDevice(ZendureBase):
                     if batprops := payload.get("packData", None):
                         for b in batprops:
                             sn = b.pop("sn")
-                            if not b:
-                                continue
 
-                            if (bat := ZendureBattery.batterydict.get(sn, None)) is None:
+                            if ((bat := ZendureBattery.batterydict.get(sn, None)) is None) and (not b):
                                 match sn[0]:
                                     case "A":
                                         if sn[3] == "3":
@@ -193,7 +191,7 @@ class ZendureDevice(ZendureBase):
                                 self._hass.loop.call_soon_threadsafe(bat.entitiesCreate, self.entitiesBattery, done)
                                 done.wait(10)
 
-                            if bat.entities:
+                            if (bat is not None) and bat.entities:
                                 for key, value in b.items():
                                     bat.entityUpdate(key, value)
                     return True

--- a/custom_components/zendure_ha/zenduredevice.py
+++ b/custom_components/zendure_ha/zenduredevice.py
@@ -171,7 +171,7 @@ class ZendureDevice(ZendureBase):
                         for b in batprops:
                             sn = b.pop("sn")
 
-                            if ((bat := ZendureBattery.batterydict.get(sn, None)) is None) and (not b):
+                            if ((bat := ZendureBattery.batterydict.get(sn, None)) is None):
                                 match sn[0]:
                                     case "A":
                                         if sn[3] == "3":
@@ -186,12 +186,16 @@ class ZendureDevice(ZendureBase):
                                         bat = ZendureBattery(self._hass, sn, "AB3000", sn, self.name, 2.88)
                                     case _:
                                         bat = ZendureBattery(self._hass, sn, "AB????", sn, self.name, 2.88)
-                                self.kwh += bat.kwh
-                                done = threading.Event()
-                                self._hass.loop.call_soon_threadsafe(bat.entitiesCreate, self.entitiesBattery, done)
-                                done.wait(10)
+                                try: 
+                                    self.kwh += bat.kwh
+                                    done = threading.Event()
+                                    self._hass.loop.call_soon_threadsafe(bat.entitiesCreate, self.entitiesBattery, done)
+                                    done.wait(10)
+                                except:
+                                    _LOGGER.info(f"Battery SN: {sn} not fully initialized!")
+                                    continue
 
-                            if (bat is not None) and bat.entities:
+                            if bat.entities:
                                 for key, value in b.items():
                                     bat.entityUpdate(key, value)
                     return True


### PR DESCRIPTION
Idea behind is, to collect every serial number of a battery and if it show up more than 2 times, add the battery to the devices. Of course this slow down adding the battery to the devices (my 3 batteries take about 90 sec to be all added) but this happens only on restart.
The assumption is, that wrong serial numbers only show up 1-2 times (for what reason ever). to increase safety, the buffer of the serial numbers could perhaps clean up after 1-2h if not added to the devices. This needs some additional code.

@Linus86529 actual test this code.