### PR TITLE
Update zendurebattery.py

### DIFF
--- a/custom_components/zendure_ha/zendurebattery.py
+++ b/custom_components/zendure_ha/zendurebattery.py
@@ -30,7 +30,7 @@ class ZendureBattery(ZendureBase):
             self.sensor("totalVol", "{{ (value / 100) }}", "V", "voltage", "measurement",1),
             self.sensor("maxVol", "{{ (value / 100) }}", "V", "voltage", "measurement",2),
             self.sensor("minVol", "{{ (value / 100) }}", "V", "voltage", "measurement",2),
-            self.sensor("batcur", "{{ (value / 10) }}", "A", "current", "measurement"),
+            self.sensor("batcur", "{{ (value / 10) }}", "A", "current", "measurement",1),
             self.sensor("state"),
             self.sensor("power", None, "W", "power", "measurement"),
             self.sensor("socLevel", None, "%", "battery", "measurement"),

--- a/custom_components/zendure_ha/zendurebattery.py
+++ b/custom_components/zendure_ha/zendurebattery.py
@@ -27,9 +27,9 @@ class ZendureBattery(ZendureBase):
 
     def entitiesCreate(self, addsensors: Callable[[ZendureBattery, list[ZendureSensor]], None], event: Any) -> None:
         sensors = [
-            self.sensor("totalVol", "{{ (value / 100) }}", "V", "voltage", "measurement"),
-            self.sensor("maxVol", "{{ (value / 100) }}", "V", "voltage", "measurement"),
-            self.sensor("minVol", "{{ (value / 100) }}", "V", "voltage", "measurement"),
+            self.sensor("totalVol", "{{ (value / 100) }}", "V", "voltage", "measurement",1),
+            self.sensor("maxVol", "{{ (value / 100) }}", "V", "voltage", "measurement",2),
+            self.sensor("minVol", "{{ (value / 100) }}", "V", "voltage", "measurement",2),
             self.sensor("batcur", "{{ (value / 10) }}", "A", "current", "measurement"),
             self.sensor("state"),
             self.sensor("power", None, "W", "power", "measurement"),


### PR DESCRIPTION
HA seems to change the precision for voltage in the last update. Define it at least for the batteries.