### PR TITLE
Update solarflow800Pro.py

### DIFF
--- a/custom_components/zendure_ha/devices/solarflow800Pro.py
+++ b/custom_components/zendure_ha/devices/solarflow800Pro.py
@@ -52,7 +52,7 @@ class SolarFlow800Pro(ZendureDevice):
         sensors = [
             self.sensor("hubState"),
             self.sensor("solarInputPower", None, "W", "power", "measurement"),
-            self.sensor("BatVolt", None, "V", "voltage", "measurement"),
+            self.sensor("BatVolt", "{{ value | int / 100 | round(1)}}", "V", "voltage", "measurement"),
             self.sensor("packInputPower", None, "W", "power", "measurement"),
             self.sensor("outputPackPower", None, "W", "power", "measurement"),
             self.sensor("outputHomePower", None, "W", "power", "measurement"),


### PR DESCRIPTION
fix BatVolt
at least this device has also a timestamp which could be changed to a readable format
perhaps somethink like `self.sensor("ts","{{ value | timestamp_custom('%x %X')}}", None, "timestamp"),`? Need to add translations also.
![image](https://github.com/user-attachments/assets/0cb1ab5f-032a-4e5a-957b-296cbe2c6804)
